### PR TITLE
Disallow back button after login

### DIFF
--- a/app/src/main/java/com/Found404/paypro/ui/pages/LoginPage.kt
+++ b/app/src/main/java/com/Found404/paypro/ui/pages/LoginPage.kt
@@ -68,14 +68,16 @@ fun LoginPage(navController: NavController) {
             onClick = {
                 coroutineScope.launch {
                     val loginResult = authService.loginUser("/api/auth/login", email, password, context)
-                    println(loginResult.success.toString() + " " + loginResult.data)
 
                     if (loginResult.success) {
 
-                        navController.navigate("addingMerchants")
+                        navController.navigate("addingMerchants") {
+                            popUpTo("welcome") {
+                                inclusive = true
+                            }
+                        }
                     } else {
                         loginErrorMessage = loginResult.message ?: "Invalid Credentials!"
-                        println("ERROR" + loginErrorMessage)
                     }
                 }
             },


### PR DESCRIPTION
Disallowing going back to the login page after successful login. Application now closes if user attempts to do that. "addingMerchants" page now acts as a root page after login. 