### PR TITLE
Resolve addingmerchant validation problems

### DIFF
--- a/app/src/main/java/com/Found404/paypro/ui/pages/CardPaymentsPage.kt
+++ b/app/src/main/java/com/Found404/paypro/ui/pages/CardPaymentsPage.kt
@@ -223,7 +223,7 @@ fun getAllSavedData(context: Context): MerchantViewModel {
     merchantViewModel.merchantData.streetName = SharedPreferencesManager.getMerchantStreetName(context).toString()
     merchantViewModel.merchantData.cityName = SharedPreferencesManager.getMerchantCity(context).toString()
     merchantViewModel.merchantData.postCode = SharedPreferencesManager.getMerchantPostCode(context)
-    merchantViewModel.merchantData.streetNumber = SharedPreferencesManager.getMerchantStreetNumber(context)
+    merchantViewModel.merchantData.streetNumber = SharedPreferencesManager.getMerchantStreetNumber(context).toString()
 
     return merchantViewModel
 }

--- a/app/src/main/java/com/Found404/paypro/ui/pages/MerchantAddresPage.kt
+++ b/app/src/main/java/com/Found404/paypro/ui/pages/MerchantAddresPage.kt
@@ -39,7 +39,7 @@ fun MerchantAddress(
     var merchantCity by remember { mutableStateOf("") }
     var merchantPostalCode by remember { mutableStateOf(0) }
     var merchantStreetName by remember { mutableStateOf("") }
-    var merchantStreetNumber by remember { mutableStateOf(0) }
+    var merchantStreetNumber by remember { mutableStateOf("") }
     var showErrorMessage by remember { mutableStateOf(false) }
 
     val validator = MerchantDataValidator()
@@ -81,9 +81,9 @@ fun MerchantAddress(
 
         PayProLabeledTextInput(
             label = "Street Number",
-            value = if (merchantStreetNumber == 0) "" else merchantStreetNumber.toString(),
-            onValueChange = { merchantStreetNumber = it.toIntOrNull() ?: 0 },
-            validation = { merchantStreetNumber -> validator.validateStreetNumber(merchantStreetNumber.toInt()).success },
+            value = merchantStreetNumber,
+            onValueChange = { merchantStreetNumber = it },
+            validation = { merchantStreetNumber -> validator.validateStreetNumber(merchantStreetNumber).success },
             modifier = Modifier.padding(horizontal = 16.dp)
         )
 
@@ -96,34 +96,8 @@ fun MerchantAddress(
         )
 
 
-//        PayProTextInput(
-//            value = merchantCity,
-//            onValueChange = { merchantCity = it },
-//            placeholder = "City name",
-//            modifier = Modifier.padding(16.dp)
-//        )
-//        PayProTextInput(
-//            value = merchantStreetName,
-//            onValueChange = { merchantStreetName = it },
-//            placeholder = "Street name",
-//            modifier = Modifier.padding(16.dp)
-//        )
-//        PayProTextInput(
-//            value = if (merchantStreetNumber == 0) "" else merchantStreetNumber.toString(),
-//            onValueChange = { merchantStreetNumber = it.toIntOrNull() ?: 0 },
-//            placeholder = "Street number",
-//            modifier = Modifier.padding(16.dp)
-//        )
-//        PayProTextInput(
-//            value = if (merchantPostalCode == 0) "" else merchantPostalCode.toString(),
-//            onValueChange = { merchantPostalCode = it.toIntOrNull() ?: 0 },
-//            placeholder = "Postal code",
-//            modifier = Modifier.padding(16.dp)
-//        )
-
         if (showErrorMessage) {
             showErrorMessages(validator, merchantCity, merchantStreetNumber, merchantPostalCode, merchantStreetName)
-//            showTextField(validator, merchantCity, merchantStreetNumber, merchantPostalCode, merchantStreetName)
         }
 
         Box(modifier = Modifier.fillMaxSize()){
@@ -139,7 +113,7 @@ fun MerchantAddress(
                     } else {
                         showErrorMessage = false
                         merchantViewModel.merchantData.cityName = merchantCity
-                        merchantViewModel.merchantData.streetNumber = merchantStreetNumber.toInt()
+                        merchantViewModel.merchantData.streetNumber = merchantStreetNumber
                         merchantViewModel.merchantData.streetName = merchantStreetName
                         merchantViewModel.merchantData.postCode = merchantPostalCode.toInt()
 
@@ -147,7 +121,7 @@ fun MerchantAddress(
                             context,
                             merchantCity,
                             merchantStreetName,
-                            merchantStreetNumber.toInt(),
+                            merchantStreetNumber,
                             merchantPostalCode.toInt()
                         )
 
@@ -180,7 +154,7 @@ fun validate(cityName: String, streetName: String, streetNumber: Int, postCode: 
 fun showErrorMessages(
     validator: MerchantDataValidator,
     merchantCity: String,
-    merchantStreetNumber: Int,
+    merchantStreetNumber: String,
     merchantPostalCode: Int,
     merchantStreetName: String
 ) {
@@ -196,47 +170,13 @@ fun showErrorMessages(
             modifier = Modifier.padding(top = 8.dp)
         )
     }
-
-//    val context = LocalContext.current
-//    if (!validator.validateCityName(merchantCity).success) {
-//        Toast.makeText(
-//            context,
-//            validator.validateCityName(merchantCity).errorMessage,
-//            Toast.LENGTH_SHORT
-//        ).show()
-//    }
-//
-//    if (!validator.validateStreetName(merchantStreetName).success) {
-//        Toast.makeText(
-//            context,
-//            validator.validateStreetName(merchantStreetName).errorMessage,
-//            Toast.LENGTH_SHORT
-//        ).show()
-//    }
-//
-//    if (!validator.validateStreetNumber(merchantStreetNumber).success) {
-//        Toast.makeText(
-//            context,
-//            validator.validateStreetNumber(merchantStreetNumber).errorMessage,
-//            Toast.LENGTH_SHORT
-//        ).show()
-//    }
-//
-//    if (!validator.validatePostCode(merchantPostalCode).success) {
-//        Toast.makeText(
-//            context,
-//            validator.validatePostCode(merchantPostalCode).errorMessage,
-//            Toast.LENGTH_SHORT
-//        ).show()
-//    }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun showTextField(
     validator: MerchantDataValidator,
     merchantCity: String,
-    merchantStreetNumber: Int,
+    merchantStreetNumber: String,
     merchantPostalCode: Int,
     merchantStreetName: String
 ) {

--- a/core/src/main/java/com/found404/core/ValidationLogic/MerchantDataValidator.kt
+++ b/core/src/main/java/com/found404/core/ValidationLogic/MerchantDataValidator.kt
@@ -12,8 +12,8 @@ class MerchantDataValidator {
         }
     }
 
-    fun validateStreetName(merchantStreetName: String) : ValidationStatus {
-        val streetNameRegex = "^[a-zA-Z]+$"
+    fun validateStreetName(merchantStreetName: String): ValidationStatus {
+        val streetNameRegex = "^[a-zA-Z]+(\\s[a-zA-Z]+)*$"
 
         return if (merchantStreetName.matches(streetNameRegex.toRegex())) {
             ValidationStatus(true)
@@ -22,18 +22,18 @@ class MerchantDataValidator {
         }
     }
 
-    fun validateCityName(merchantCityName : String) : ValidationStatus {
-        val cityNameRegex = "^[a-zA-Z]+$"
+    fun validateCityName(merchantCityName: String): ValidationStatus {
+        val cityNameRegex = "^[a-zA-Z]+(\\s[a-zA-Z]+)*$"
 
-        return if (merchantCityName.matches(cityNameRegex.toRegex())){
+        return if (merchantCityName.matches(cityNameRegex.toRegex())) {
             ValidationStatus(true)
         } else {
-            return ValidationStatus(false, "Invalid city name!")
+            ValidationStatus(false, "Invalid city name!")
         }
     }
 
     fun validatePostCode(merchantPostCode : Int) : ValidationStatus {
-        val postCodeRegex = "^[1-9]+$"
+        val postCodeRegex = "^[0-9]+$"
 
         return if (merchantPostCode.toString().matches(postCodeRegex.toRegex())) {
             ValidationStatus(true)
@@ -42,10 +42,10 @@ class MerchantDataValidator {
         }
     }
 
-    fun validateStreetNumber(merchantStreetNumber: Int) : ValidationStatus {
-        val streetNumberRegex = "^[1-9]+$"
+    fun validateStreetNumber(merchantStreetNumber: String): ValidationStatus {
+        val streetNumberRegex = "^[a-zA-Z0-9]+$"
 
-        return if (merchantStreetNumber.toString().matches(streetNumberRegex.toRegex())){
+        return if (merchantStreetNumber.matches(streetNumberRegex.toRegex())) {
             ValidationStatus(true)
         } else {
             ValidationStatus(false, "Invalid street number!")

--- a/core/src/main/java/com/found404/core/models/Merchant.kt
+++ b/core/src/main/java/com/found404/core/models/Merchant.kt
@@ -9,7 +9,7 @@ data class Merchant (
     var cityName: String = "",
     var streetName: String = "",
     var postCode: Int = 0,
-    var streetNumber: Int = 0,
+    var streetNumber: String = "",
     var cardTypes: List<CreditCardType> = emptyList(),
     var status: StatusType = StatusType.ACTIVE
 )

--- a/core/src/main/java/com/found404/core/models/SharedPreferencesManager.kt
+++ b/core/src/main/java/com/found404/core/models/SharedPreferencesManager.kt
@@ -27,13 +27,13 @@ object SharedPreferencesManager {
         return sharedPreferences.getString(KEY_MERCHANT_NAME, null)
     }
 
-    fun saveMerchantAddress(context: Context, merchantCity: String, streetName: String, streetNumber: Int, postalCode: Int) {
+    fun saveMerchantAddress(context: Context, merchantCity: String, streetName: String, streetNumber: String, postalCode: Int) {
         val sharedPreferences: SharedPreferences =
             context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
         val editor: SharedPreferences.Editor = sharedPreferences.edit()
         editor.putString(KEY_MERCHANT_CITY, merchantCity)
         editor.putString(KEY_STREET_NAME, streetName)
-        editor.putInt(KEY_STREET_NUMBER, streetNumber)
+        editor.putString(KEY_STREET_NUMBER, streetNumber)
         editor.putInt(KEY_POSTAL_CODE, postalCode)
         editor.apply()
     }
@@ -50,10 +50,10 @@ object SharedPreferencesManager {
         return sharedPreferences.getString(KEY_STREET_NAME, null)
     }
 
-    fun getMerchantStreetNumber(context: Context): Int {
+    fun getMerchantStreetNumber(context: Context): String? {
         val sharedPreferences: SharedPreferences =
             context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return sharedPreferences.getInt(KEY_STREET_NUMBER, 0)
+        return sharedPreferences.getString(KEY_STREET_NUMBER, null)
     }
 
     fun getMerchantPostCode(context: Context): Int {

--- a/network/src/main/java/com/found404/network/service/AddingMerchantService.kt
+++ b/network/src/main/java/com/found404/network/service/AddingMerchantService.kt
@@ -10,7 +10,7 @@ interface AddingMerchantService {
         merchantStreetName: String,
         merchantCityName: String,
         merchantPostCode: Int,
-        merchantStreetNumber: Int,
+        merchantStreetNumber: String,
         acceptedCards: List<Map<String, Any>>,
         status: String
     ) : AddingMerchantsResult

--- a/network/src/main/java/com/found404/network/service/implementation/AddingMerchantsServiceImplementation.kt
+++ b/network/src/main/java/com/found404/network/service/implementation/AddingMerchantsServiceImplementation.kt
@@ -24,7 +24,7 @@ class AddingMerchantsServiceImplementation : AddingMerchantService {
         merchantStreetName: String,
         merchantCityName: String,
         merchantPostCode: Int,
-        merchantStreetNumber: Int,
+        merchantStreetNumber: String,
         acceptedCards: List<Map<String, Any>>,
         status: String
     ): AddingMerchantsResult = withContext(Dispatchers.IO) {


### PR DESCRIPTION
Resolved address validation problems in adding merchant functionality

- PostalCode didnt allow zeros, it now does
- StreetNumber didnt allow letters. It now does. For example (123a, 54b)
- CityName didnt allow cities with multiple words. It now does. For example (New York)